### PR TITLE
Tim/ietf 125

### DIFF
--- a/draft-ietf-v6ops-rfc7084bis.xml
+++ b/draft-ietf-v6ops-rfc7084bis.xml
@@ -783,6 +783,8 @@
           <t>Added P flag, and when it can be supported.</t>
           <t>Added PRefix Delegation on LAN requirements, RFC 9818</t>
           <t>Added RA Guard, which MUST NOT be enabled by default.</t>
+          <t>Added an exception to the RA Guard requirement for backup routers and SNAC deployments.</t>
+          <t>Added support for DNS over HTTPS (RFC 8484) and DNS over TLS (RFC 7858).</t>
           <t>Added Hop-by-Hop Processing to the General Section. </t>
           <t>Added support for SLAAC renumbering.</t>
           <t>Clarified that Link-Local packets should not be forwarded.</t>
@@ -796,7 +798,7 @@
           <t>Updated to use RFC 8415 for DHCPv6</t>
           <t>Updated to use RFC 7157 for mutlihoming discussion.</t>
           <t>Updated to use RFC 8106 for DNS options in Router Advertisements.</t>
-          <t>Updated to use RFC 8405 for IPv6 node requirements.</t> 
+          <t>Updated to use RFC 8504 for IPv6 node requirements.</t>
           <t>Updated S-2 requirement to a MUST to prevent spoofing attacks.</t> 
           <t>Added a requirement to not utilize EUI-64 address.</t> 
        </list>

--- a/draft-ietf-v6ops-rfc7084bis.xml
+++ b/draft-ietf-v6ops-rfc7084bis.xml
@@ -11,7 +11,7 @@
 <?rfc sortrefs="yes" ?>
 <?rfc compact="yes" ?>
 <?rfc subcompact="no" ?>
-<rfc category="bcp" ipr="trust200902" submissionType="IETF" consensus="true" obsoletes="7084" docName="draft-ietf-v6ops-rfc7084bis-05">
+<rfc category="bcp" ipr="trust200902" submissionType="IETF" consensus="true" obsoletes="7084,9818" docName="draft-ietf-v6ops-rfc7084bis-06">
   <front>
     <title abbrev="IPv6 CE Router Requirements">Basic Requirements for IPv6
     Customer Edge Routers</title>
@@ -644,7 +644,11 @@
             <xref target="I-D.ietf-6man-slaac-renum"></xref>.</t>
 
             <t>The IPv6 CE router MUST NOT enable IPv6 Router Advertisement Guard, <xref target="RFC6105"></xref>, by 
-            default.</t>
+            default. This requirement enables functionality like backup routers
+            or SNAC <xref target="I-D.ietf-snac-simple"></xref> without administrator intervention. In an environment
+            with malicious hosts an administrator may want to enable RA Guard for those hosts.</t>
+
+            <t> The IPv6 CE router SHOULD implement <xref target="RFC8484"/> (DoH), and MAY support <xref target="RFC7858"/> (DoT). </t>
       
           </list></t>
           <t>LAN Prefix Delegation requirements (RFC 9818):<list style="format LPD-%d:"> 
@@ -831,9 +835,11 @@
       <?rfc include='reference.RFC.7721.xml'?>
       <?rfc include='reference.RFC.7772.xml'?>
       <?rfc include='reference.RFC.7844.xml'?>
+      <?rfc include='reference.RFC.7858.xml'?>
       <?rfc include='reference.RFC.8064.xml'?>
       <?rfc include='reference.RFC.8106.xml'?>
       <?rfc include='reference.RFC.8415.xml'?>
+      <?rfc include='reference.RFC.8484.xml'?>
       <?rfc include='reference.RFC.8504.xml'?>
       <?rfc include='reference.RFC.8585.xml'?>
       <?rfc include='reference.RFC.9096.xml'?>
@@ -844,7 +850,7 @@
 </references>
 
 <references title="Informative References">
-
+      <?rfc include="reference.I-D.ietf-snac-simple.xml"?>
       <reference anchor="UPnP-IGD" target="http://upnp.org/specs/gw/igd2/">
         <front>
           <title>InternetGatewayDevice:2 Device Template Version 1.01</title>

--- a/draft-ietf-v6ops-rfc7084bis.xml
+++ b/draft-ietf-v6ops-rfc7084bis.xml
@@ -532,7 +532,7 @@
             target="RFC4193"></xref>, whether or not WAN connectivity
             exists.</t>
 
-            <t>IPv6 hosts should be capable of using SLAAC and may be capable
+            <t>IPv6 hosts are capable of using SLAAC and may be capable
             of using DHCPv6 for acquiring their addresses.</t>
 
             <t>IPv6 hosts may use DHCPv6 for other configuration information,


### PR DESCRIPTION

Here's a summary of what changed between -05 and -06:

Clarified that IPv6 hosts are capable of using SLAAC (previously "should be capable"), removing ambiguity about SLAAC support. (Issue #11)

Added an exception to the RA Guard requirement: RA Guard MUST NOT be enabled by default, but the text now explicitly notes this enables functionality like backup routers or SNAC (per draft-ietf-snac-simple) without administrator intervention, while noting an administrator may still want to enable RA Guard in environments with malicious hosts. (Issue #13)

Added new requirements for encrypted DNS: the IPv6 CE router SHOULD implement DNS over HTTPS (RFC 8484) and MAY support DNS over TLS (RFC 7858).

Updated the "obsoletes" list to include RFC 9818 alongside RFC 7084, and bumped the document name to -06.

Added normative reference entries for RFC 7858 and RFC 8484, and an informative reference entry for draft-ietf-snac-simple, to support the new text above.

Fixed the changelog appendix itself: corrected an entry that mistakenly cited "RFC 8405" for IPv6 node requirements — it should be RFC 8504 (the RFC actually cited in the body and references section).
